### PR TITLE
Add configurable IP for servers

### DIFF
--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Backend2BackendRest.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Backend2BackendRest.java
@@ -1,6 +1,7 @@
 package io.openems.backend.b2brest;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -43,7 +44,7 @@ public class Backend2BackendRest extends AbstractOpenemsBackendComponent {
 
 	@Activate
 	private void activate(Config config) throws OpenemsException {
-		this.startServer(config.port());
+		this.startServer(config.ip(), config.port());
 	}
 
 	@Deactivate
@@ -57,9 +58,13 @@ public class Backend2BackendRest extends AbstractOpenemsBackendComponent {
 	 * @param port the port
 	 * @throws OpenemsException on error
 	 */
-	private synchronized void startServer(int port) throws OpenemsException {
+	private synchronized void startServer(String ip, int port) throws OpenemsException {
 		try {
-			this.server = new Server(port);
+			this.server = new Server();
+			final var connector = new ServerConnector(this.server);
+			connector.setHost(ip);
+			connector.setPort(port);
+			this.server.addConnector(connector);
 			this.server.setHandler(new RestHandler(this));
 			this.server.start();
 			this.logInfo(this.log, "Backend2Backend.Rest started on port [" + port + "].");

--- a/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Config.java
+++ b/io.openems.backend.b2brest/src/io/openems/backend/b2brest/Config.java
@@ -7,6 +7,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 		name = "Backend2Backend.Rest", //
 		description = "Provides a REST-Api server for backend-to-backend communication.")
 @interface Config {
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the REST server. ('0.0.0.0' for any IP)")
+	String ip() default "127.0.0.1";
 
 	@AttributeDefinition(name = "Port", description = "The port of the REST server.")
 	int port() default Backend2BackendRest.DEFAULT_PORT;

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Backend2BackendWebsocket.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Backend2BackendWebsocket.java
@@ -88,7 +88,7 @@ public class Backend2BackendWebsocket extends AbstractOpenemsBackendComponent im
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
+			this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
 			this.server.start();
 		}
 	}

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Config.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/Config.java
@@ -7,7 +7,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 		name = "Backend2Backend.Websocket", //
 		description = "Provides a websocket server for backend-to-backend communication.")
 @interface Config {
-
+@AttributeDefinition(name = "IP-Address", description = "The IP address of the websocket server. ('0.0.0.0' for any IP)")
+	String ip() default "127.0.0.1";
+	
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default Backend2BackendWebsocket.DEFAULT_PORT;
 

--- a/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WebsocketServer.java
+++ b/io.openems.backend.b2bwebsocket/src/io/openems/backend/b2bwebsocket/WebsocketServer.java
@@ -14,8 +14,8 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(Backend2BackendWebsocket parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
+	public WebsocketServer(Backend2BackendWebsocket parent, String name, String ip, int port, int poolSize) {
+		super(name, ip, port, poolSize);
 		this.parent = parent;
 		this.onOpen = new OnOpen(//
 				() -> parent.metadata, //

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/Config.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/Config.java
@@ -7,6 +7,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 		name = "Edge.Websocket", //
 		description = "Configures the websocket server for OpenEMS Edge")
 @interface Config {
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the websocket server. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
 
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default 8081;

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/EdgeWebsocketImpl.java
@@ -112,10 +112,10 @@ public class EdgeWebsocketImpl extends AbstractOpenemsBackendComponent
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
-			this.server.start();
-		}
-	}
+                       this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
+                       this.server.start();
+               }
+       }
 
 	/**
 	 * Stop existing websocket server.

--- a/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
+++ b/io.openems.backend.edgewebsocket/src/io/openems/backend/edgewebsocket/WebsocketServer.java
@@ -24,9 +24,9 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(EdgeWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
-		this.parent = parent;
+       public WebsocketServer(EdgeWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+               super(name, ip, port, poolSize);
+               this.parent = parent;
 		this.onOpen = new OnOpen(parent);
 		this.onRequest = new OnRequest(//
 				() -> parent.appCenterMetadata, //

--- a/io.openems.backend.metrics.prometheus/src/io/openems/backend/metrics/prometheus/Config.java
+++ b/io.openems.backend.metrics.prometheus/src/io/openems/backend/metrics/prometheus/Config.java
@@ -8,6 +8,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 		description = "Metrics endpoint for prometheus.")
 @interface Config {
 
+	@AttributeDefinition(name = "IP-Address", description = "The IP address to bind the metrics server. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
+
 	@AttributeDefinition(name = "Port", description = "Http port")
 	int port() default 9400;
 

--- a/io.openems.backend.metrics.prometheus/src/io/openems/backend/metrics/prometheus/PrometheusClient.java
+++ b/io.openems.backend.metrics.prometheus/src/io/openems/backend/metrics/prometheus/PrometheusClient.java
@@ -58,7 +58,7 @@ public class PrometheusClient extends AbstractOpenemsBackendComponent implements
 		this.prometheusRegistry.register(PrometheusMetrics.ALERTING_MESSAGES_QUEUE);
 		this.prometheusRegistry.register(PrometheusMetrics.ALERTING_MESSAGES_SENT);
 
-		this.startServer(config.port(), config.bearerToken());
+               this.startServer(config.ip(), config.port(), config.bearerToken());
 	}
 
 	@Deactivate
@@ -69,10 +69,11 @@ public class PrometheusClient extends AbstractOpenemsBackendComponent implements
 		this.prometheusRegistry.clear();
 	}
 
-	private void startServer(int port, String bearerToken) {
+	private void startServer(String ip, int port, String bearerToken) {
 		try {
-			final var httpServerBuilder = HTTPServer.builder() //
-					.port(port) //
+                       final var httpServerBuilder = HTTPServer.builder() //
+                                       .host(ip) //
+                                       .port(port) //
 					.registry(this.prometheusRegistry);
 			if (bearerToken != null && !bearerToken.isBlank()) {
 				httpServerBuilder.authenticator(new Authenticator() {
@@ -86,8 +87,8 @@ public class PrometheusClient extends AbstractOpenemsBackendComponent implements
 					}
 				});
 			}
-			this.server = httpServerBuilder.buildAndStart();
-			this.log.info("Started /metrics endpoint on port %s".formatted(this.server.getPort()));
+	this.server = httpServerBuilder.buildAndStart();
+	this.log.info("Started /metrics endpoint on port %s".formatted(this.server.getPort()));
 		} catch (IOException e) {
 			this.log.error(e.getMessage());
 		}

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/Config.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/Config.java
@@ -7,6 +7,8 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 		name = "Ui.Websocket", //
 		description = "Configures the websocket server for OpenEMS UI")
 @interface Config {
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the websocket server. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
 
 	@AttributeDefinition(name = "Port", description = "The port of the websocket server.")
 	int port() default 8082;

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/UiWebsocketImpl.java
@@ -100,11 +100,11 @@ public class UiWebsocketImpl extends AbstractOpenemsBackendComponent
 	 */
 	private synchronized void startServer() {
 		if (this.server == null) {
-			this.server = new WebsocketServer(this, this.getName(), this.config.port(), this.config.poolSize());
-			this.server.start();
-			this.uiWebsocketValidator.start(this.server);
-		}
-	}
+                       this.server = new WebsocketServer(this, this.getName(), this.config.ip(), this.config.port(), this.config.poolSize());
+                       this.server.start();
+                       this.uiWebsocketValidator.start(this.server);
+               }
+       }
 
 	/**
 	 * Stop existing websocket server.

--- a/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
+++ b/io.openems.backend.uiwebsocket/src/io/openems/backend/uiwebsocket/impl/WebsocketServer.java
@@ -14,10 +14,10 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnNotification onNotification;
 	private final OnError onError;
 
-	public WebsocketServer(UiWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
-		this.parent = parent;
-		this.onRequest = new OnRequest(parent);
+       public WebsocketServer(UiWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+               super(name, ip, port, poolSize);
+               this.parent = parent;
+               this.onRequest = new OnRequest(parent);
 		this.onNotification = new OnNotification(parent);
 		this.onError = new OnError(parent);
 	}

--- a/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/AbstractWebsocketServer.java
@@ -32,8 +32,9 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	 */
 	private final ThreadPoolExecutor executor;
 
-	private final Logger log = LoggerFactory.getLogger(AbstractWebsocketServer.class);
-	private final int port;
+       private final Logger log = LoggerFactory.getLogger(AbstractWebsocketServer.class);
+       private final String ip;
+       private final int port;
 	private final WebSocketServer ws;
 	private final Collection<WebSocket> connections = ConcurrentHashMap.newKeySet();
 
@@ -46,13 +47,14 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 	 * @param port     to listen on
 	 * @param poolSize number of threads dedicated to handle the tasks
 	 */
-	protected AbstractWebsocketServer(String name, int port, int poolSize) {
-		super(name);
-		this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(poolSize,
-				new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
+       protected AbstractWebsocketServer(String name, String ip, int port, int poolSize) {
+               super(name);
+               this.executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(poolSize,
+                               new ThreadFactoryBuilder().setNameFormat(name + "-%d").build());
 
-		this.port = port;
-		this.ws = new WebSocketServer(new InetSocketAddress(port),
+               this.ip = ip;
+               this.port = port;
+               this.ws = new WebSocketServer(new InetSocketAddress(ip, port),
 				/* AVAILABLE_PROCESSORS */ Runtime.getRuntime().availableProcessors(), //
 				/* drafts, no filter */ List.of(new MyDraft6455()), //
 				this.connections) {
@@ -235,8 +237,8 @@ public abstract class AbstractWebsocketServer<T extends WsData> extends Abstract
 		this.isStarted = true;
 		super.start();
 		this.logInfo(this.log, "Starting websocket server [port=" + this.port + "]");
-		this.ws.start();
-	}
+               this.ws.start();
+       }
 
 	/**
 	 * Execute a {@link Runnable} using the shared {@link ExecutorService}.

--- a/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
+++ b/io.openems.common/src/io/openems/common/websocket/DummyWebsocketServer.java
@@ -86,10 +86,10 @@ public class DummyWebsocketServer extends AbstractWebsocketServer<WsData> implem
 
 	private final DummyWebsocketServer.Builder builder;
 
-	private DummyWebsocketServer(DummyWebsocketServer.Builder builder) {
-		super("DummyWebsocketServer", 0 /* auto-select port */, 1 /* pool size */);
-		this.builder = builder;
-	}
+       private DummyWebsocketServer(DummyWebsocketServer.Builder builder) {
+               super("DummyWebsocketServer", "127.0.0.1", 0 /* auto-select port */, 1 /* pool size */);
+               this.builder = builder;
+       }
 
 	@Override
 	protected WsData createWsData(WebSocket ws) {

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/AbstractRestApi.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/AbstractRestApi.java
@@ -58,8 +58,8 @@ public abstract class AbstractRestApi extends AbstractOpenemsComponent
 	 *                           assigned
 	 * @param connectionlimit    the connection limit
 	 */
-	protected void activate(ComponentContext context, String id, String alias, boolean enabled,
-			boolean isDebugModeEnabled, int apiTimeout, int port, int connectionlimit) {
+       protected void activate(ComponentContext context, String id, String alias, boolean enabled,
+                       boolean isDebugModeEnabled, int apiTimeout, String ip, int port, int connectionlimit) {
 		super.activate(context, id, alias, enabled);
 		this.isDebugModeEnabled = isDebugModeEnabled;
 
@@ -77,8 +77,9 @@ public abstract class AbstractRestApi extends AbstractOpenemsComponent
 			httpConfig.setUriCompliance(UriCompliance.from(Set.of(//
 					UriCompliance.Violation.SUSPICIOUS_PATH_CHARACTERS, //
 					UriCompliance.Violation.ILLEGAL_PATH_CHARACTERS)));
-			final var connector = new ServerConnector(this.server, new HttpConnectionFactory(httpConfig));
-			connector.setPort(port);
+                       final var connector = new ServerConnector(this.server, new HttpConnectionFactory(httpConfig));
+                       connector.setHost(ip);
+                       connector.setPort(port);
 			this.server.addConnector(connector);
 			this.server.setHandler(new RestHandler(this));
 			this.server.addBean(new AcceptRateLimit(10, 5, TimeUnit.SECONDS, this.server));

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/Config.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/Config.java
@@ -21,6 +21,8 @@ import io.openems.edge.controller.api.rest.AbstractRestApi;
 
 	@AttributeDefinition(name = "Port", description = "Port on which the webserver should listen.")
 	int port() default 8084;
+	@AttributeDefinition(name = "IP-Address", description = "The IP address on which the webserver should listen. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
 
 	@AttributeDefinition(name = "Connection limit", description = "Maximum number of connections")
 	int connectionlimit() default 5;

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImpl.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readonly/ControllerApiRestReadOnlyImpl.java
@@ -50,8 +50,8 @@ public class ControllerApiRestReadOnlyImpl extends AbstractRestApi
 	private void activate(ComponentContext context, Config config) throws OpenemsException {
 		this.restHandler = this.restHandlerFactory.get();
 
-		super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), 0, /* no timeout */
-				config.port(), config.connectionlimit());
+               super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), 0, /* no timeout */
+                               config.ip(), config.port(), config.connectionlimit());
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/Config.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/Config.java
@@ -21,6 +21,8 @@ import io.openems.edge.controller.api.rest.AbstractRestApi;
 
 	@AttributeDefinition(name = "Port", description = "Port on which the webserver should listen.")
 	int port() default 8084;
+	@AttributeDefinition(name = "IP-Address", description = "The IP address on which the webserver should listen. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
 
 	@AttributeDefinition(name = "Connection limit", description = "Maximum number of connections")
 	int connectionlimit() default 5;

--- a/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImpl.java
+++ b/io.openems.edge.controller.api.rest/src/io/openems/edge/controller/api/rest/readwrite/ControllerApiRestReadWriteImpl.java
@@ -51,8 +51,8 @@ public class ControllerApiRestReadWriteImpl extends AbstractRestApi
 	private void activate(ComponentContext context, Config config) throws OpenemsException {
 		this.restHandler = this.restHandlerFactory.get();
 
-		super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), config.apiTimeout(),
-				config.port(), config.connectionlimit());
+               super.activate(context, config.id(), config.alias(), config.enabled(), config.debugMode(), config.apiTimeout(),
+                               config.ip(), config.port(), config.connectionlimit());
 	}
 
 	@Override

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/Config.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/Config.java
@@ -17,6 +17,9 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 	@AttributeDefinition(name = "Is enabled?", description = "Is this Component enabled?")
 	boolean enabled() default true;
 
+	@AttributeDefinition(name = "IP-Address", description = "The IP address of the websocket server. (0.0.0.0 for any IP)")
+	String ip() default "127.0.0.1";
+
 	@AttributeDefinition(name = "Port", description = "Port on which the Websocket server should listen.")
 	int port() default 8085;
 

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImpl.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/ControllerApiWebsocketImpl.java
@@ -92,7 +92,7 @@ public class ControllerApiWebsocketImpl extends AbstractOpenemsComponent
 			call.put(ComponentConfigRequestHandler.API_WORKER_KEY, this.apiWorker);
 		});
 		this.onRequest.setDebug(config.debugMode());
-		this.startServer(config.port(), POOL_SIZE);
+               this.startServer(config.ip(), config.port(), POOL_SIZE);
 
 	}
 
@@ -111,10 +111,10 @@ public class ControllerApiWebsocketImpl extends AbstractOpenemsComponent
 	 * @param port     the port
 	 * @param poolSize number of threads dedicated to handle the tasks
 	 */
-	private synchronized void startServer(int port, int poolSize) {
-		this.server = new WebsocketServer(this, "Websocket Api", port, poolSize);
-		this.server.start();
-	}
+       private synchronized void startServer(String ip, int port, int poolSize) {
+               this.server = new WebsocketServer(this, "Websocket Api", ip, port, poolSize);
+               this.server.start();
+       }
 
 	/**
 	 * Stop existing websocket server.

--- a/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketServer.java
+++ b/io.openems.edge.controller.api.websocket/src/io/openems/edge/controller/api/websocket/WebsocketServer.java
@@ -16,10 +16,10 @@ public class WebsocketServer extends AbstractWebsocketServer<WsData> {
 	private final OnError onError;
 	private final OnClose onClose;
 
-	public WebsocketServer(ControllerApiWebsocketImpl parent, String name, int port, int poolSize) {
-		super(name, port, poolSize);
-		this.parent = parent;
-		this.onNotification = new OnNotification(parent);
+       public WebsocketServer(ControllerApiWebsocketImpl parent, String name, String ip, int port, int poolSize) {
+               super(name, ip, port, poolSize);
+               this.parent = parent;
+               this.onNotification = new OnNotification(parent);
 		this.onError = new OnError(parent);
 		this.onClose = new OnClose(parent);
 	}


### PR DESCRIPTION
## Summary
- add IP address option to various server configs
- default servers to bind `127.0.0.1`
- pass IP to Jetty and WebSocket servers
- update AbstractWebsocketServer to bind to a specific address
- adjust Prometheus metrics client and REST API activation
- revert log messages to keep minimal changes

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9048bb48330a6b7ba532d36494b