### PR TITLE
Restrict edge list visibility to owners

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -35,7 +35,7 @@
                     <ion-label translate>Menu.overview </ion-label>
                   </ion-item>
                 </ng-container>
-                <ng-container *ngIf="service.edges as edges">
+                <ng-container *ngIf="isUserAllowedToSeeSidebarEdgeList && service.edges as edges">
                   <ion-accordion-group>
                     <ion-accordion>
                       <ion-item slot="header" lines="full">

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -28,6 +28,7 @@ export class AppComponent implements OnInit, OnDestroy {
   public isSystemLogEnabled: boolean = false;
 
   protected isUserAllowedToSeeOverview: boolean = false;
+  protected isUserAllowedToSeeSidebarEdgeList: boolean = false;
   protected isUserAllowedToSeeFooter: boolean = false;
   protected isHistoryDetailView: boolean = false;
   protected position: WritableSignal<"left" | "bottom" | null> = signal(null);
@@ -57,6 +58,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this.service.metadata.pipe(filter(metadata => !!metadata)).subscribe(metadata => {
         this.isUserAllowedToSeeOverview = UserPermission.isUserAllowedToSeeOverview(metadata.user);
         this.isUserAllowedToSeeFooter = UserPermission.isUserAllowedToSeeFooter(metadata.user);
+        this.isUserAllowedToSeeSidebarEdgeList = UserPermission.isUserAllowedToSeeSidebarEdgeList(metadata.user);
       }));
 
     this.subscription.add(

--- a/ui/src/app/shared/shared.ts
+++ b/ui/src/app/shared/shared.ts
@@ -121,6 +121,10 @@ export class UserPermission {
     return user.hasMultipleEdges;
   }
 
+  public static isUserAllowedToSeeSidebarEdgeList(user: User): boolean {
+    return Role.isAtLeast(user.globalRole, Role.OWNER);
+  }
+
   /**
   * Checks if user is allowed to see {@link SystemRestartComponent}
   *


### PR DESCRIPTION
## Summary
- add permission helper to check owner rights
- use the new check to only show edge switcher to owners
- rename sidebar permission variable

## Testing
- `npm test --silent` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_685bb31ce01c8321afcd950cddccc241