### PR TITLE
Fix member ordering in service

### DIFF
--- a/ui/src/app/shared/service/service.ts
+++ b/ui/src/app/shared/service/service.ts
@@ -79,9 +79,6 @@ export class Service extends AbstractService {
     user: User, edges: { [edgeId: string]: Edge }
   }> = new BehaviorSubject(null);
 
-  public get edges() {
-    return this.metadata.value?.edges;
-  }
 
   /**
    * Holds the current Activated Route
@@ -116,6 +113,10 @@ export class Service extends AbstractService {
     translate.onLangChange.subscribe((event: LangChangeEvent) => {
       this.setLang(Language.getByKey(event.lang));
     });
+  }
+
+  public get edges() {
+    return this.metadata.value?.edges;
   }
 
   public setLang(language: Language) {


### PR DESCRIPTION
## Summary
- fix ESLint member ordering warning in Service class

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_685be1b950ac832184bb94ca956c0cdd