### PR TITLE
Make new navigation optional

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -35,7 +35,7 @@
                     <ion-label translate>Menu.overview </ion-label>
                   </ion-item>
                 </ng-container>
-                <ng-container *ngIf="isUserAllowedToSeeSidebarEdgeList && service.edges as edges">
+                  <ng-container *ngIf="environment.enableSidebarEdgeList && isUserAllowedToSeeSidebarEdgeList && service.edges as edges">
                   <ion-accordion-group>
                     <ion-accordion>
                       <ion-item slot="header" lines="full">

--- a/ui/src/environments/index.ts
+++ b/ui/src/environments/index.ts
@@ -19,6 +19,8 @@ export interface Environment {
     readonly production: boolean;
     debugMode: boolean;
 
+    readonly enableSidebarEdgeList: boolean;
+
     readonly docsUrlPrefix: string;
     readonly links: {
 

--- a/ui/src/themes/openems/environments/theme.ts
+++ b/ui/src/themes/openems/environments/theme.ts
@@ -7,6 +7,7 @@ export const theme = {
     edgeShortName: "OpenEMS",
     edgeLongName: "Open Energy Management System",
     defaultLanguage: "de",
+    enableSidebarEdgeList: false,
 
     docsUrlPrefix: "https://github.com/OpenEMS/openems/blob/develop/",
     links: {


### PR DESCRIPTION
## Summary
- rename optional flag to `enableSidebarEdgeList`
- revert navigation-related gating and only use the flag for the edge list
- default the new flag to `false` in the theme

## Testing
- `npm run lint` *(fails: `ng` not found)*
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686228d1aa7c832187d27f892a5417f5